### PR TITLE
added a new node to get the subscribers by email

### DIFF
--- a/nodes/Listmonk/businessOperations/subscribers.ts
+++ b/nodes/Listmonk/businessOperations/subscribers.ts
@@ -49,6 +49,20 @@ export const subscriberOperations: INodeProperties[] = [
 				},
 			},
 			{
+				name: 'Get by Email',
+				value: 'getByEmail',
+				action: 'Get by Email',
+				routing: {
+					request: {
+						method: 'GET',
+						url: '/subscribers',
+						qs: {
+							query: '=email=\'{{$parameter.subscriberEmail}}\'',
+						},
+					},
+				},
+			},
+			{
 				name: 'Get Subscriber by ID',
 				value: 'geSubscriberById',
 				action: 'Get subscriber by id',

--- a/nodes/Listmonk/options.ts
+++ b/nodes/Listmonk/options.ts
@@ -340,4 +340,17 @@ export const listmonkOptions: INodeProperties[] = [
 			},
 		},
 	},
+	{
+		displayName: 'Subscriber Email',
+		description: 'Search subscriber by email address. Although the email address in listmonk a unique field, it doesn\'t provide a direct API to get one the subscriber by email address. This method will return a list of subscribers if found, containing one element.',
+		required: true,
+		name: 'subscriberEmail',
+		type: 'string',
+		default: '',
+		displayOptions: {
+			show: {
+				operation: ['getByEmail'],
+			},
+		},
+	},
 ];

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "n8n-nodes-listmonk",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "n8n-nodes-listmonk",
-      "version": "1.0.3",
+      "version": "1.0.4",
       "license": "MIT",
       "devDependencies": {
         "@types/express": "^4.17.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "n8n-nodes-listmonk",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "A n8n node to interact with Listmonk app",
   "keywords": [
     "n8n-community-node-package",


### PR DESCRIPTION
first of all thanks to you @LucasSovre for building this awesome node.

I was researching this node and came across your nodes. during my workflow I realized that the standard query for subscribers is missing. As i was looking for the query of subscribers by email address based in the use case I have,  thought of extending the same. here is the example of the workflow.

<img width="1508" alt="image" src="https://github.com/LucasSovre/listmonk-n8n/assets/3868003/1c9a85d2-54dd-4db2-b865-52d8b972c78a">

creating the pull request so that in case other are interested in similar use case, they can get benefitted from the work.

i have also took the liberty to bump up the version.

let me know in case you feel there are some modifications needed.