### PR TITLE
added a node to get all the subscribers by list id

### DIFF
--- a/nodes/Listmonk/businessOperations/subscribers.ts
+++ b/nodes/Listmonk/businessOperations/subscribers.ts
@@ -63,6 +63,20 @@ export const subscriberOperations: INodeProperties[] = [
 				},
 			},
 			{
+				name: 'Get by List ID',
+				value: 'getByListId',
+				action: 'Get by list id',
+				routing: {
+					request: {
+						method: 'GET',
+						url: '/subscribers',
+						qs: {
+							list_id: '={{$parameter.listId}}',
+						},
+					},
+				},
+			},
+			{
 				name: 'Get Subscriber by ID',
 				value: 'geSubscriberById',
 				action: 'Get subscriber by id',

--- a/nodes/Listmonk/options.ts
+++ b/nodes/Listmonk/options.ts
@@ -328,6 +328,19 @@ export const listmonkOptions: INodeProperties[] = [
 		},
 	},
 	{
+		displayName: 'List ID',
+		description: 'Get all the subscribers by list id.',
+		required: true,
+		name: 'listId',
+		type: 'number',
+		default: '',
+		displayOptions: {
+			show: {
+				operation: ['getByListId'],
+			},
+		},
+	},
+	{
 		displayName: 'Preconfirm Subscriptions',
 		name: 'preconfirmSubscriptions',
 		type: 'boolean',

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "n8n-nodes-listmonk",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "n8n-nodes-listmonk",
-      "version": "1.0.4",
+      "version": "1.0.5",
       "license": "MIT",
       "devDependencies": {
         "@types/express": "^4.17.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "n8n-nodes-listmonk",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "A n8n node to interact with Listmonk app",
   "keywords": [
     "n8n-community-node-package",


### PR DESCRIPTION
In my pull request, I've introduced a crucial enhancement to the project by enabling the retrieval of subscribers based on their list ID. This addition significantly augments the project's functionality, providing users with a streamlined method to manage subscribers efficiently. By incorporating this feature, we empower users to navigate and utilize the project's capabilities more effectively, ultimately enhancing their overall experience. I believe this enhancement aligns seamlessly with the project's objectives and will greatly benefit the community by addressing a common requirement and improving usability.